### PR TITLE
HMA-1521: Make hint text grey 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Allowed headings:
 
 ## [Unreleased]
 
+### Changed
+
+* Updated the color of all text hints from black to grey 1
+
 ## [3.7.0] - 2021-01-21
 
 ### Changed

--- a/components/src/main/res/values/styles.xml
+++ b/components/src/main/res/values/styles.xml
@@ -105,7 +105,7 @@
 
     <style name="TextInput" parent="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox">
         <item name="android:gravity">top|start</item>
-        <item name="android:textColorHint">@color/hmrc_dark_text</item>
+        <item name="android:textColorHint">@color/hmrc_grey_1</item>
         <item name="boxCornerRadiusBottomEnd">0dp</item>
         <item name="boxCornerRadiusBottomStart">0dp</item>
         <item name="boxCornerRadiusTopEnd">0dp</item>


### PR DESCRIPTION
# 📝 Description

JIRA Issue
https://jira.tools.tax.service.gov.uk/browse/HMA-1521

Changes the hint text from black to grey 1
  
- [x] Updated CHANGELOG

# 🛠 Testing Notes

This will affect any the following components:
- Text Input View
- Currency Input View

# 📸 Screenshots

## Light mode

| Before | After |
| ------------- | ------------- |
| ![HMA-1521-before-light](https://user-images.githubusercontent.com/6881571/105710957-c0e03780-5f0f-11eb-88bd-97f95b7b9ad5.png) | ![HMA-1521-after-light](https://user-images.githubusercontent.com/6881571/105710975-c9d10900-5f0f-11eb-8667-af454f7b9c92.png) |

## Dark mode

| Before | After |
| ------------- | ------------- |
| ![HMA-1521-before-dark](https://user-images.githubusercontent.com/6881571/105711015-d9e8e880-5f0f-11eb-90b4-d32cbbcbb1a8.png) | ![HMA-1521-after-dark](https://user-images.githubusercontent.com/6881571/105711044-e3725080-5f0f-11eb-84c4-ed096b5a3cce.png) |

# 🎨 Colour contrast results

| Light mode | Dark mode |
| ------------- | ------------- |
| <img width="480" alt="HMA-1521-contrast-results-light-mode" src="https://user-images.githubusercontent.com/6881571/105711836-fcc7cc80-5f10-11eb-9bb1-5cc92cc82ef4.png"> | <img width="480" alt="HMA-1521-contrast-results-dark-mode" src="https://user-images.githubusercontent.com/6881571/105711876-06e9cb00-5f11-11eb-8efe-6a9f012f04c1.png"> |