### PR TITLE
HMA-4082 enable publishing using `fastlane/.env` for environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,4 +104,5 @@ flavor.xml
 # fastlane specific
 fastlane/report.xml
 fastlane/Preview.html
+fastlane/.env
 .bundle/

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -12,7 +12,7 @@ Install _fastlane_ using
 ```
 [sudo] gem install fastlane -NV
 ```
-or alternatively using `brew install fastlane`
+or alternatively using `brew cask install fastlane`
 
 # Available Actions
 ## Android


### PR DESCRIPTION
# 📝 Description
  
* Ignore `fastlane/.env` so new the components library can be released when setting your environment variables via `fastlane/.env`
* Updated `fastlane/README.md` to match the generated one from fastlane

# 🛠 Testing Notes

# 📸 Screenshots
