### PR TITLE
HMA-4458: Update MenuPanelRowView touch state colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Allowed headings:
 
 ## [Unreleased]
 
+### Changed
+
+* Updated `MenuPanelRowView` touch state colour
+
 ## [3.11.0] - 2021-04-13
 
 ### Added

--- a/components/src/main/java/uk/gov/hmrc/components/organism/menu/MenuPanelRowView.kt
+++ b/components/src/main/java/uk/gov/hmrc/components/organism/menu/MenuPanelRowView.kt
@@ -56,6 +56,7 @@ class MenuPanelRowView @JvmOverloads constructor(
         }
         if (isLargeText) adjustLayoutForBigText()
         setBackgroundColor(ContextCompat.getColor(context, R.color.hmrc_grey_3))
+        setRippleColorResource(R.color.hmrc_secondary_button_ripple)
     }
 
     private fun setDefaultContentDescription(title: CharSequence, body: CharSequence) {

--- a/components/src/main/res/layout/component_menu_panel_row.xml
+++ b/components/src/main/res/layout/component_menu_panel_row.xml
@@ -18,6 +18,7 @@
     android:id="@+id/layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="@drawable/components_ripple_background"
     android:focusable="true"
     android:paddingStart="@dimen/hmrc_spacing_16"
     android:paddingTop="@dimen/hmrc_spacing_24"

--- a/components/src/main/res/layout/component_menu_panel_row.xml
+++ b/components/src/main/res/layout/component_menu_panel_row.xml
@@ -18,7 +18,6 @@
     android:id="@+id/layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@drawable/components_ripple_background"
     android:focusable="true"
     android:paddingStart="@dimen/hmrc_spacing_16"
     android:paddingTop="@dimen/hmrc_spacing_24"


### PR DESCRIPTION
# 📝 Description

https://jira.tools.tax.service.gov.uk/browse/HMA-4458

Change the touch state colour of the `MenuPanelRowView` to be blue (instead of grey) like some of the other components
  
- [x] Updated CHANGELOG

**Marc is happy with the latest colour**

# 🛠 Testing Notes

# 📸 Screenshots

## New (after PR feedback):

Fixed issue where colour was too dark.

<img width="381" alt="HMA-4458-ripple" src="https://user-images.githubusercontent.com/6881571/116396241-108b1380-a81d-11eb-8ba9-4e293dc1cce7.png">

<img width="381" alt="HMA-4458-ripple-2" src="https://user-images.githubusercontent.com/6881571/116396628-842d2080-a81d-11eb-8167-2cb4eb706f23.png">

## Old (before PR feedback):

This had an issue where the colour was too dark.

<img width="520" alt="HMA-4458" src="https://user-images.githubusercontent.com/6881571/116058502-d2082400-a677-11eb-9401-14ce1eff6e69.png">