### PR TITLE
HMA-4463: Added ability to set error content description on TextInputView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Allowed headings:
 
 ## [Unreleased]
 
+### Changed
+
+* Added ability to set error content descriptions on `TextInputView` 
+
 ## [3.12.0] - 2021-04-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -296,6 +296,8 @@ multi_column_row.setText1AsHeading(true)
  - Custom content description
  - Max length limits
  - Character counters
+ - Error messages
+ - Error message content descriptions
 
 ### Currency Input View
 

--- a/components/src/main/java/uk/gov/hmrc/components/molecule/input/TextInputView.kt
+++ b/components/src/main/java/uk/gov/hmrc/components/molecule/input/TextInputView.kt
@@ -134,8 +134,13 @@ open class TextInputView @JvmOverloads constructor(
         binding.root.errorContentDescription = errorContentDescription ?: errorText
     }
 
-    fun setErrorText(@StringRes error: Int?) {
-        binding.root.error = if (error == null) null else context.getString(error)
+    fun setErrorText(@StringRes error: Int?, @StringRes errorContentDescription: Int? = null) {
+        setError(
+            errorText = if (error == null) null else context.getString(error),
+            errorContentDescription = if (errorContentDescription == null) {
+                null
+            } else context.getString(errorContentDescription)
+        )
     }
 
     fun setCounterMaxLength(maxLength: Int) {

--- a/components/src/main/java/uk/gov/hmrc/components/molecule/input/TextInputView.kt
+++ b/components/src/main/java/uk/gov/hmrc/components/molecule/input/TextInputView.kt
@@ -129,8 +129,9 @@ open class TextInputView @JvmOverloads constructor(
 
     fun getError() = binding.root.error
 
-    fun setError(errorText: CharSequence?) {
+    fun setError(errorText: CharSequence?, errorContentDescription: CharSequence? = null) {
         binding.root.error = errorText
+        binding.root.errorContentDescription = errorContentDescription ?: errorText
     }
 
     fun setErrorText(@StringRes error: Int?) {


### PR DESCRIPTION
# 📝 Description

* Added ability to set error content description on `TextInputView`

- [x] Updated CHANGELOG
- [x] Updated README 

# 🛠 Testing Notes

Test accessibility of `TextInputView` and its subclasses.