### PR TITLE
TextInputView accessibility improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,13 @@ Allowed headings:
 
 ## [Unreleased]
 
-### Changed
+### Added
 
 * Added ability to set error content descriptions on `TextInputView`
+
+### Changed
+
+* Improved content description for `TextInputView` to announce the error and counter status along with the hint on talkback.
 * Upgrade target and compile sdk versions to 30
 * Upgrade Gradle plugin to 4.1.3
 * Upgrade Kotlin version to 1.4.20

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ multi_column_row.setText1AsHeading(true)
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     app:text="@string/text"
-    app:overrideHintContentDescription="@string/content_description"
+    app:hintContentDescription="@string/content_description"
     app:counterEnabled="true"
     app:counterMaxLength="@integer/max_length"
     app:hintText="@string/hint_text" />

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ ext {
     android_x_annotation_version = '1.0.2'
     android_x_recyclerview_version = '1.0.0'
     android_x_constraint_layout_version = '1.1.3'
-    material_version = '1.2.1'
+    material_version = '1.3.0'
     lifecycleVersion = '2.1.0'
 
     junit_version = '4.12'

--- a/components/src/main/java/uk/gov/hmrc/components/molecule/input/TextInputView.kt
+++ b/components/src/main/java/uk/gov/hmrc/components/molecule/input/TextInputView.kt
@@ -52,14 +52,16 @@ open class TextInputView @JvmOverloads constructor(
             binding.root.id = value
         }
 
+    private var hintContentDescription: String? = null
+
     init {
 
         attrs?.let {
             val typedArray = context.theme.obtainStyledAttributes(it, R.styleable.TextInputView, 0, 0)
 
             val textString = typedArray.getString(R.styleable.TextInputView_text) ?: ""
-            val overrideHintContentDescription = typedArray.getString(
-                R.styleable.TextInputView_overrideHintContentDescription)
+            val hintTextContentDescription = typedArray.getString(
+                R.styleable.TextInputView_hintContentDescription)
             val hintText = typedArray.getString(R.styleable.TextInputView_hintText) ?: ""
             val errorText = typedArray.getString(R.styleable.TextInputView_errorText) ?: ""
             val counterMaxLength = typedArray.getInt(R.styleable.TextInputView_counterMaxLength, NO_MAX_LENGTH)
@@ -70,8 +72,7 @@ open class TextInputView @JvmOverloads constructor(
             val maxLength = typedArray.getInt(R.styleable.TextInputView_android_maxLength, -1)
 
             setText(textString)
-            overrideHintContentDescription(overrideHintContentDescription)
-            setHint(hintText)
+            setHint(hintText, hintTextContentDescription)
             setError(errorText)
             setCounterMaxLength(counterMaxLength)
             setCounterEnabled(counterEnabled)
@@ -108,30 +109,19 @@ open class TextInputView @JvmOverloads constructor(
 
     fun getText(): String? = getEditText().text?.toString()
 
-    fun overrideHintContentDescription(contentDescription: CharSequence?) {
-        contentDescription ?: return
-
-        binding.root.apply {
-            setTextInputAccessibilityDelegate(object : TextInputLayout.AccessibilityDelegate(this) {
-                override fun onInitializeAccessibilityNodeInfo(host: View, info: AccessibilityNodeInfoCompat) {
-                    super.onInitializeAccessibilityNodeInfo(host, info)
-                    val before = info.text.toString()
-                    val after = before.replace(hint.toString(), contentDescription.toString())
-                    info.text = after
-                }
-            })
-        }
-    }
-
-    fun setHint(hint: CharSequence) {
+    fun setHint(hint: CharSequence, contentDescription: CharSequence? = null) {
         binding.root.hint = hint
+        hintContentDescription = (contentDescription ?: hint).toString()
+        updateTextInputViewContentDescription()
     }
 
     fun getError() = binding.root.error
 
     fun setError(errorText: CharSequence?, errorContentDescription: CharSequence? = null) {
         binding.root.error = errorText
-        binding.root.errorContentDescription = errorContentDescription ?: errorText
+        binding.root.errorContentDescription = errorContentDescription ?:
+                if (errorText.isNullOrEmpty()) "" else context.getString(R.string.accessibility_error_prefix, errorText)
+        updateTextInputViewContentDescription()
     }
 
     fun setErrorText(@StringRes error: Int?, @StringRes errorContentDescription: Int? = null) {
@@ -145,10 +135,12 @@ open class TextInputView @JvmOverloads constructor(
 
     fun setCounterMaxLength(maxLength: Int) {
         binding.root.counterMaxLength = maxLength
+        updateTextInputViewContentDescription()
     }
 
     fun setCounterEnabled(enabled: Boolean) {
         binding.root.isCounterEnabled = enabled
+        updateTextInputViewContentDescription()
     }
 
     fun setPrefixText(prefixText: CharSequence?) {
@@ -176,6 +168,27 @@ open class TextInputView @JvmOverloads constructor(
     }
 
     fun getEditText(): TextInputEditText = binding.root.findViewWithTag("edit_text")
+
+    private fun updateTextInputViewContentDescription() {
+        val customHint = hintContentDescription ?: binding.root.hint
+        val error = if (binding.root.errorContentDescription.isNullOrEmpty()) {
+            ""
+        } else ", ${binding.root.errorContentDescription}"
+        val counter = if (binding.root.isCounterEnabled) ", ${binding.root.counterMaxLength}" else ""
+
+        val newContentDescription = "$customHint$error$counter"
+
+        binding.root.apply {
+            setTextInputAccessibilityDelegate(object : TextInputLayout.AccessibilityDelegate(this) {
+                override fun onInitializeAccessibilityNodeInfo(host: View, info: AccessibilityNodeInfoCompat) {
+                    super.onInitializeAccessibilityNodeInfo(host, info)
+                    val before = info.text.toString()
+                    val after = before.replace(hint.toString(), newContentDescription)
+                    info.text = after
+                }
+            })
+        }
+    }
 
     companion object {
         private const val STATE_TEXT = "STATE_TEXT"

--- a/components/src/main/java/uk/gov/hmrc/components/molecule/input/TextInputView.kt
+++ b/components/src/main/java/uk/gov/hmrc/components/molecule/input/TextInputView.kt
@@ -17,6 +17,7 @@ package uk.gov.hmrc.components.molecule.input
 
 import android.content.Context
 import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES.O
 import android.os.Bundle
 import android.os.Parcelable
 import android.text.InputFilter
@@ -119,8 +120,9 @@ open class TextInputView @JvmOverloads constructor(
 
     fun setError(errorText: CharSequence?, errorContentDescription: CharSequence? = null) {
         binding.root.error = errorText
-        binding.root.errorContentDescription = errorContentDescription ?:
-                if (errorText.isNullOrEmpty()) "" else context.getString(R.string.accessibility_error_prefix, errorText)
+        binding.root.errorContentDescription = errorContentDescription ?: if (!errorText.isNullOrEmpty()) {
+            context.getString(R.string.accessibility_error_prefix, errorText)
+        } else ""
         updateTextInputViewContentDescription()
     }
 
@@ -172,9 +174,8 @@ open class TextInputView @JvmOverloads constructor(
     private fun updateTextInputViewContentDescription() {
         val customHint = hintContentDescription ?: binding.root.hint
 
-        val error = if (binding.root.errorContentDescription.isNullOrEmpty()) {
-            ""
-        } else ", ${binding.root.errorContentDescription}"
+        val errorContentDescription = binding.root.errorContentDescription
+        val error = if (errorContentDescription.isNullOrEmpty()) "" else ", $errorContentDescription"
 
         val counter = if (binding.root.isCounterEnabled) {
             val currentChars = if (getText().isNullOrEmpty()) "0" else getText()?.length.toString()
@@ -189,7 +190,7 @@ open class TextInputView @JvmOverloads constructor(
                 override fun onInitializeAccessibilityNodeInfo(host: View, info: AccessibilityNodeInfoCompat) {
                     super.onInitializeAccessibilityNodeInfo(host, info)
                     val showingText = !editText?.text.isNullOrEmpty()
-                    if (VERSION.SDK_INT >= 26) {
+                    if (VERSION.SDK_INT >= O) {
                         if (showingText) {
                             info.hintText = newContentDescription
                         } else {

--- a/components/src/main/java/uk/gov/hmrc/components/molecule/input/TextInputView.kt
+++ b/components/src/main/java/uk/gov/hmrc/components/molecule/input/TextInputView.kt
@@ -171,10 +171,16 @@ open class TextInputView @JvmOverloads constructor(
 
     private fun updateTextInputViewContentDescription() {
         val customHint = hintContentDescription ?: binding.root.hint
+
         val error = if (binding.root.errorContentDescription.isNullOrEmpty()) {
             ""
         } else ", ${binding.root.errorContentDescription}"
-        val counter = if (binding.root.isCounterEnabled) ", ${binding.root.counterMaxLength}" else ""
+
+        val counter = if (binding.root.isCounterEnabled) {
+            val currentChars = if (getText().isNullOrEmpty()) "0" else getText()?.length.toString()
+            val maxLength = binding.root.counterMaxLength.toString()
+            ", ${context.getString(R.string.accessibility_counter_state, currentChars, maxLength)}"
+        } else ""
 
         val newContentDescription = "$customHint$error$counter"
 

--- a/components/src/main/res/values/attrs.xml
+++ b/components/src/main/res/values/attrs.xml
@@ -39,7 +39,7 @@
         <!-- Text to display. -->
         <attr name="text" />
         <!-- Hint content description. -->
-        <attr name="overrideHintContentDescription" format="string" />
+        <attr name="hintContentDescription" format="string" />
         <!-- Hint text. -->
         <attr name="hintText" format="string" />
         <!-- Error text. -->

--- a/components/src/main/res/values/strings.xml
+++ b/components/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="accessibility_radio_button">radio button</string>
     <string name="accessibility_list_position">%1d of %2d</string>
     <string name="accessibility_tab_position">tab %1d of %2d</string>
+    <string name="accessibility_error_prefix">Error: %s</string>
 
     <string name="currency_input_prefix">£</string>
 </resources>

--- a/components/src/main/res/values/strings.xml
+++ b/components/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@
     <string name="accessibility_list_position">%1d of %2d</string>
     <string name="accessibility_tab_position">tab %1d of %2d</string>
     <string name="accessibility_error_prefix">Error: %s</string>
+    <string name="accessibility_counter_state">%1$s characters of %2$s used</string>
 
     <string name="currency_input_prefix">£</string>
 </resources>

--- a/sample/src/main/res/layout/fragment_text_input.xml
+++ b/sample/src/main/res/layout/fragment_text_input.xml
@@ -30,7 +30,6 @@
                 android:layout_marginStart="@dimen/hmrc_spacing_16"
                 android:layout_marginTop="@dimen/hmrc_spacing_16"
                 android:layout_marginEnd="@dimen/hmrc_spacing_16"
-                app:contentDescription="@string/text_input_placeholder_hint"
                 app:counterEnabled="true"
                 app:counterMaxLength="@integer/text_input_placeholder_max_length"
                 app:hintText="@string/text_input_placeholder_hint" />
@@ -57,6 +56,8 @@
                     android:layout_marginStart="@dimen/hmrc_spacing_16"
                     android:layout_marginTop="@dimen/hmrc_spacing_16"
                     android:layout_marginEnd="@dimen/hmrc_spacing_16"
+                    app:counterEnabled="true"
+                    app:counterMaxLength="@integer/text_input_placeholder_max_length"
                     app:hintContentDescription="@string/text_input_example_1_content_description"
                     app:hintText="@string/text_input_example_1_hint" />
 

--- a/sample/src/main/res/layout/fragment_text_input.xml
+++ b/sample/src/main/res/layout/fragment_text_input.xml
@@ -57,7 +57,7 @@
                     android:layout_marginStart="@dimen/hmrc_spacing_16"
                     android:layout_marginTop="@dimen/hmrc_spacing_16"
                     android:layout_marginEnd="@dimen/hmrc_spacing_16"
-                    app:overrideHintContentDescription="@string/text_input_example_1_content_description"
+                    app:hintContentDescription="@string/text_input_example_1_content_description"
                     app:hintText="@string/text_input_example_1_hint" />
 
                 <uk.gov.hmrc.components.molecule.input.TextInputView


### PR DESCRIPTION
# 📝 Description

When talkback focus is given to a TextInputView, we want the user to be made aware of any errors or character limits associated with that view. We also want to be able to support custom hint content descriptions.
  
- [-] Updated CHANGELOG

# 🛠 Testing Notes

When talkback focus is given to a TextInputView, it should announce "[hint], [character limit], [error]" as required. 
Note: The second example ("Message") on the Text Input View screen in the sample app already contains a custom hint message. 
Also need to check that the Currency Input View is working as expected.

# 📸 Screenshots
