### PR TITLE
HMA-4514: Fix TextInput end icon keyboard issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Allowed headings:
 
 ## [Unreleased]
 
+### Changed
+
+* Improved keyboard navigation for `TextInputView`
+
 ## [3.14.2] - 2021-05-26
 
 ### Added

--- a/components/src/main/java/uk/gov/hmrc/components/molecule/input/TextInputView.kt
+++ b/components/src/main/java/uk/gov/hmrc/components/molecule/input/TextInputView.kt
@@ -28,6 +28,7 @@ import android.widget.FrameLayout
 import androidx.annotation.StringRes
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.core.view.updatePadding
+import androidx.core.widget.doOnTextChanged
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import uk.gov.hmrc.components.R
@@ -89,6 +90,20 @@ open class TextInputView @JvmOverloads constructor(
         }
         editTextId = View.generateViewId()
         layoutId = View.generateViewId()
+
+        setupEndIcon()
+    }
+
+    private fun setupEndIcon() {
+        binding.root.setEndIconOnClickListener {
+            setText(null)
+        }
+
+        binding.root.isEndIconVisible = !getText().isNullOrBlank()
+
+        getEditText().doOnTextChanged { text, _, _, _ ->
+            binding.root.isEndIconVisible = !text.isNullOrBlank()
+        }
     }
 
     override fun onSaveInstanceState(): Parcelable? {

--- a/components/src/main/res/layout/component_text_input.xml
+++ b/components/src/main/res/layout/component_text_input.xml
@@ -10,9 +10,11 @@
     app:prefixTextAppearance="@style/Text.Body"
     app:prefixTextColor="@color/hmrc_dark_text"
     app:errorEnabled="true"
-    app:endIconMode="clear_text"
+    app:endIconMode="custom"
     app:endIconTint="@color/hmrc_black"
+    app:endIconCheckable="false"
     app:endIconDrawable="@drawable/components_ic_clear"
+    app:endIconContentDescription="@string/text_input_clear_button_content_description"
     tools:hint="@string/text_input_example_hint">
 
     <com.google.android.material.textfield.TextInputEditText

--- a/components/src/main/res/values/strings.xml
+++ b/components/src/main/res/values/strings.xml
@@ -42,4 +42,5 @@
     <string name="accessibility_counter_limit_exceeded">Character limit exceeded</string>
 
     <string name="currency_input_prefix">£</string>
+    <string name="text_input_clear_button_content_description">Clear text</string>
 </resources>


### PR DESCRIPTION
# 📝 Description

https://jira.tools.tax.service.gov.uk/browse/HMA-4514

Fixed issue where TextInput end icon was making the keyboard get stuck.
  
- [x] Updated CHANGELOG

# 🛠 Testing Notes

Sample app: go to text input view screen and enter text in a field. Press tab. You should be able to exit the field.