### PR TITLE
Expose MultiColumnRow setTextFocusable method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Allowed headings:
 
 ## [Unreleased]
 
+### Added
+
+* Exposed the `setTextFocusable(focusable: Boolean)` for use in `MultiColumnRow` and provided `isTextFocusable` for setting this in xml.
+
 ## [3.15.1] - 2021-07-01Z
 
 * Updated `hmrc_yellow`

--- a/components/src/main/java/uk/gov/hmrc/components/molecule/item/MultiColumnRowView.kt
+++ b/components/src/main/java/uk/gov/hmrc/components/molecule/item/MultiColumnRowView.kt
@@ -55,11 +55,13 @@ class MultiColumnRowView @JvmOverloads constructor(
             val textStyle2 = typedArray.getResourceId(R.styleable.MultiColumnRowView_textStyle2, textStyle)
             val textStyle3 = typedArray.getResourceId(R.styleable.MultiColumnRowView_textStyle3, textStyle)
             val text1Heading = typedArray.getBoolean(R.styleable.MultiColumnRowView_text1Heading, false)
+            val isTextFocusable = typedArray.getBoolean(R.styleable.MultiColumnRowView_isTextFocusable, true)
 
             setText(text1, text2, text3)
             setTextContentDescription(text1ContentDescription, text2ContentDescription, text3ContentDescription)
             setTextStyle(textStyle, textStyle2, textStyle3)
             setText1AsHeading(text1Heading)
+            setTextFocusable(isTextFocusable)
 
             typedArray.recycle()
         }
@@ -191,7 +193,7 @@ class MultiColumnRowView @JvmOverloads constructor(
         binding.rowText1.setAsAccessibilityHeading(isHeading)
     }
 
-    internal fun setTextFocusable(focusable: Boolean) {
+    fun setTextFocusable(focusable: Boolean) {
         binding.apply {
             rowText1.isFocusable = focusable
             rowText2.isFocusable = focusable

--- a/components/src/main/res/values/attrs.xml
+++ b/components/src/main/res/values/attrs.xml
@@ -96,6 +96,7 @@
         <attr name="textStyle3" format="reference" />
         <!-- Whether or not the first piece of text should be an accessibility heading. -->
         <attr name="text1Heading" format="boolean" />
+        <attr name="isTextFocusable" format="boolean" />
     </declare-styleable>
 
     <declare-styleable name="SwitchRowView">

--- a/sample/src/main/res/layout/fragment_multi_column_row.xml
+++ b/sample/src/main/res/layout/fragment_multi_column_row.xml
@@ -180,6 +180,25 @@
 
         </com.google.android.material.card.MaterialCardView>
 
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/hmrc_spacing_16"
+            android:layout_marginTop="@dimen/hmrc_spacing_16"
+            android:layout_marginEnd="@dimen/hmrc_spacing_16"
+            android:contentDescription="card content description">
+
+            <uk.gov.hmrc.components.molecule.item.MultiColumnRowView
+                android:id="@+id/multi_column_row_example_9"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="@dimen/hmrc_spacing_16"
+                app:text1="@string/multi_column_row_placeholder_text1"
+                app:text2="@string/multi_column_row_placeholder_text2"
+                app:isTextFocusable="false" />
+
+        </com.google.android.material.card.MaterialCardView>
+
     </LinearLayout>
 
 </ScrollView>


### PR DESCRIPTION
# 📝 Description

Exposed the `setTextFocusable(focusable: Boolean)` for use in `MultiColumnRow` and provided `isTextFocusable` for setting this in xml. 
  
- [-] Updated CHANGELOG

# 🛠 Testing Notes

Have added an example in the Sample app at the bottom of the MultiColumnRow section, where the content description is added to the parent card and so none of the multicolumn rows should be individually focusable. 

# 📸 Screenshots
