### PR TITLE
Add click listener to headline card view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Allowed headings:
 
 ## [Unreleased]
 
+### Added
+
+* Added `setOnClickListener(clickHandler: () -> Unit)` and `setChevronContentDescription(description: CharSequence)` methods to `HeadlineCardView`.
+
 ## [3.16.0] - 2021-07-16
 
 ### Added

--- a/components/src/main/java/uk/gov/hmrc/components/organism/headline/HeadlineCardView.kt
+++ b/components/src/main/java/uk/gov/hmrc/components/organism/headline/HeadlineCardView.kt
@@ -18,7 +18,9 @@ package uk.gov.hmrc.components.organism.headline
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
+import android.view.View
 import android.widget.LinearLayout
+import androidx.core.view.children
 import uk.gov.hmrc.components.R
 import uk.gov.hmrc.components.base.DynamicCardView
 import uk.gov.hmrc.components.base.PaddedComponent
@@ -32,7 +34,7 @@ open class HeadlineCardView @JvmOverloads constructor(
 
     private val binding: ComponentHeadlineCardBinding =
             ComponentHeadlineCardBinding.inflate(LayoutInflater.from(context), this, true)
-    override val childContainer: LinearLayout = binding.layout
+    override val childContainer: LinearLayout = binding.headlineLayout
 
     init {
         attrs?.let { it ->
@@ -67,6 +69,24 @@ open class HeadlineCardView @JvmOverloads constructor(
 
     fun setTitleContentDescription(desc: String?) {
         desc?.let { binding.title.contentDescription = it }
+    }
+
+    fun setOnClickListener(clickHandler: () -> Unit) {
+        setRippleColorResource(R.color.hmrc_secondary_button_ripple)
+        super.setOnClickListener {
+            clickHandler.invoke()
+        }
+        ensureChildViewsAreFocusable()
+        binding.imageChevron.visibility = View.VISIBLE
+    }
+
+    // This method can be used as an accessibility aid for informing talkback users of the result of tapping the view.
+    fun setChevronContentDescription(description: CharSequence) {
+        binding.imageChevron.contentDescription = description
+    }
+
+    private fun ensureChildViewsAreFocusable() {
+        childContainer.children.forEach { childView -> childView.isFocusable = true }
     }
 
     override fun removeChildPadding() {

--- a/components/src/main/res/layout/component_headline_card.xml
+++ b/components/src/main/res/layout/component_headline_card.xml
@@ -14,29 +14,52 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/layout"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:padding="@dimen/hmrc_spacing_16">
+    android:layout_height="wrap_content">
 
-    <uk.gov.hmrc.components.atom.heading.Heading5
-        android:id="@+id/title"
+    <LinearLayout
+        android:id="@+id/headline_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:gravity="start"
-        android:layout_marginBottom="@dimen/hmrc_spacing_24"
-        tools:text="Title" />
+        android:layout_toStartOf="@id/image_chevron"
+        android:orientation="vertical"
+        android:padding="@dimen/hmrc_spacing_16">
 
-    <TextView
-        android:id="@+id/headline"
-        style="@style/Text.H3"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/hmrc_spacing_24"
-        android:gravity="start"
-        tools:text="Headline" />
+        <uk.gov.hmrc.components.atom.heading.Heading5
+            android:id="@+id/title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="start"
+            android:layout_marginBottom="@dimen/hmrc_spacing_24"
+            android:focusable="true"
+            tools:text="Title" />
 
-</LinearLayout>
+        <TextView
+            android:id="@+id/headline"
+            style="@style/Text.H3"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/hmrc_spacing_24"
+            android:gravity="start"
+            android:focusable="true"
+            tools:text="Headline" />
+
+    </LinearLayout>
+
+    <ImageView
+        android:id="@+id/image_chevron"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_alignParentEnd="true"
+        android:layout_centerVertical="true"
+        android:layout_marginEnd="@dimen/hmrc_spacing_16"
+        android:visibility="gone"
+        android:focusable="true"
+        android:contentDescription="@string/accessibility_button_activate"
+        android:src="@drawable/components_ic_chevron_right"
+        app:tint="@color/hmrc_black" />
+
+</RelativeLayout>

--- a/sample/src/main/java/uk/gov/hmrc/components/sample/organisms/HeadlineCardFragment.kt
+++ b/sample/src/main/java/uk/gov/hmrc/components/sample/organisms/HeadlineCardFragment.kt
@@ -40,6 +40,11 @@ class HeadlineCardFragment : BaseComponentsFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.apply {
+            headlinePlaceholder.setOnClickListener { onCtaPressed() }
+            headlineExample.apply {
+                setOnClickListener { onCtaPressed() }
+                setChevronContentDescription(getString(R.string.headline_example_chevron_content_description))
+            }
             headlineExample3Button.setOnClickListener { onCtaPressed() }
             headlineExample4Button.setOnClickListener { onCtaPressed() }
             headlineExample5Button.setOnClickListener { onCtaPressed() }

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -229,6 +229,7 @@
 	</string>
     <string name="headline_example_button">View tax estimate</string>
     <string name="headline_example_icon_button">How is this calculated?</string>
+    <string name="headline_example_chevron_content_description">Income tax estimate. Button. Double tap to view these details in your web browser.</string>
 
     <!-- H4 -->
     <string name="h4_placeholder_title">Title</string>


### PR DESCRIPTION
# 📝 Description

Add ability to have clickable headline card views. If the click listener is set, then the chevon is visible. The content description can also be overriden for the chevron.
  
- [x] Updated CHANGELOG
- [ ] Updated README

# 🛠 Testing Notes
Have added a click action to the placeholder example in the Sample app. 
Have added a click action and overridden the chevron content description for the first example in the sample app.

# 📸 Screenshots
<img width="461" alt="Screenshot 2021-07-23 at 14 05 19" src="https://user-images.githubusercontent.com/7998113/126785792-d86c8b67-f2b0-43a2-b282-0ec51ee6e38b.png">
