### PR TITLE
HMA-5118 Update status view to support vectors wider than 100dp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Allowed headings:
 
 ## [Unreleased]
 
-* Updated `StatusCardView` to support vectors than are more than 100dp wide
+* Updated `StatusCardView` to improve support for vectors than are more than 100dp wide
 
 ## [3.18.0] - 2021-10-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Allowed headings:
 
 ## [Unreleased]
 
+* Updated `StatusCardView` to support vectors than are more than 100dp wide
+
 ## [3.18.0] - 2021-10-22
 
 * Added Java 11 support

--- a/components/src/main/res/layout/component_status.xml
+++ b/components/src/main/res/layout/component_status.xml
@@ -19,7 +19,8 @@
 
     <ImageView
         android:id="@+id/icon"
-        android:layout_width="@dimen/icon_height"
+        android:minWidth="@dimen/icon_height"
+        android:layout_width="wrap_content"
         android:layout_height="@dimen/icon_height"
         android:layout_gravity="center"
         tools:ignore="ContentDescription"

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -64,6 +64,6 @@ Runs the screenshot comparison
 
 ----
 
-This README.md is auto-generated and will be re-generated every time [fastlane](https://fastlane.tools) is run.
+This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
 More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).
 The documentation of fastlane can be found on [docs.fastlane.tools](https://docs.fastlane.tools).

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -20,7 +20,7 @@ android {
         targetSdkVersion target_sdk_version
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "com.karumi.shot.ShotTestRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -20,7 +20,7 @@ android {
         targetSdkVersion target_sdk_version
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "com.karumi.shot.ShotTestRunner"
     }
     buildTypes {
         release {


### PR DESCRIPTION
# 📝 Description

The pay by bank vector in https://jira.tools.tax.service.gov.uk/browse/HMA-5118 is `200dp` wide.

`StatusView` fixes the width of the icon to be `100dp`. This means that the vector is scaled down.

To fix this I have set `minWidth` to `100dp` and the `width` to `wrap_content`.

This will mean that for all the existing icons, it'll still be 100dp wide, but for icons wider than 100dp, it will take up more horizontal space on the screen. This is fine because in `StatusView` there is nothing on either side of the icon, so it can take up all the space it wants.

- [x] Updated CHANGELOG
- [x] Updated README (not needed)

# 🛠 Testing Notes

Retest `StatusView` and `StatusCard` usages

# 📸 Screenshots

FYI - the vector was temporarily added to generate these screenshots

| Before | After |
| ------ | ------ |
| ![HMA-5118-components-update-before](https://user-images.githubusercontent.com/6881571/140338422-3947be03-2f8d-40a7-b92b-fd442ff7088c.png) | ![HMA-5118-components-update](https://user-images.githubusercontent.com/6881571/140338459-f0ecc55b-a688-49f0-831a-58a62c23eb37.png) |

