### PR TITLE
Update master branch to main for tagging releases

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -43,9 +43,11 @@ platform :android do
     UI.user_error!("You need to provide the Bitrise app slug for this repo via a `ANDROID_COMPONENTS_APP_SLUG` environment variable") unless !ENV["ANDROID_COMPONENTS_APP_SLUG"].nil?
     UI.user_error!("You need to provide the Bitrise release workflow ID this repo via a `ANDROID_COMPONENTS_RELEASE_WORKFLOW_ID` environment variable") unless !ENV["ANDROID_COMPONENTS_RELEASE_WORKFLOW_ID"].nil?
 
-    # ensure repo is clean and on master
+    # ensure repo is clean and on main
     ensure_git_status_clean
-    ensure_git_branch
+    ensure_git_branch(
+      branch: 'main'
+    )
 
     # pull latest changes and fetch tags
     git_pull
@@ -124,9 +126,11 @@ platform :android do
       UI.user_error!("Please updated the version in components-test/build.gradle before publishing")
     end
 
-    # ensure repo is clean and on master
+    # ensure repo is clean and on main
     ensure_git_status_clean
-    ensure_git_branch
+    ensure_git_branch(
+      branch: 'main'
+    )
 
     # pull latest changes and fetch tags
     git_pull
@@ -149,9 +153,11 @@ platform :android do
 
   desc "Publishes components test library"
   lane :publish_test do
-    # ensure repo is clean and on master
+    # ensure repo is clean and on main
     ensure_git_status_clean
-    ensure_git_branch
+    ensure_git_branch(
+      branch: 'main'
+    )
 
     check
 

--- a/release_test_version.sh
+++ b/release_test_version.sh
@@ -6,7 +6,7 @@ curl --location --request POST "https://api.bitrise.io/v0.1/apps/$ANDROID_COMPON
 --header 'Content-Type: application/json' \
 --data-raw '{
   "build_params": {
-    "tag": "master",
+    "tag": "main",
     "workflow_id": "'$ANDROID_COMPONENTS_TEST_RELEASE_WORKFLOW_ID'"
   },
   "hook_info": {


### PR DESCRIPTION
# 📝 Description

By default, the Fastlane command: `ensure_git_branch` looks for `master`, but we have now renamed to `main` so we need to specify this. 

# 🛠 Testing Notes

# 📸 Screenshots
