### PR TITLE
HMA-5694: TabBarView large long text resize issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Allowed headings:
 
 ## [Unreleased]
 
+### Changed
+
+* Updated `TabBarView` to fix bugs when the component is used with large text or long, dynamic tab titles.
+
 ## [4.0.0] - 2022-03-25
 
 ### Changed


### PR DESCRIPTION
# 📝 Description

When `TabBarView` was used with dynamic tab titles of different lengths, toggling between the titles (from longer to a shorter title, then back to long again) meant the text auto-resized rather than keeping the initial scroll function.

Additionally, if the user had large text enabled and toggled between titles, the tab bar spacing would keep increasing.

Both should be fixed.
  
- [x] Updated CHANGELOG
- [ ] Updated README

# 🛠 Testing Notes

# 📸 Screenshots
