### PR TITLE
Add multicolumnrow whole row content description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Allowed headings:
 
 ## [Unreleased]
 
+### Additions
+
+* Added ability to give a whole row content description on `MultiColumnRow`s.
+
 ## [4.3.0] - 2022-11-25
 
 ### Additions

--- a/components/src/main/java/uk/gov/hmrc/components/molecule/item/MultiColumnRowView.kt
+++ b/components/src/main/java/uk/gov/hmrc/components/molecule/item/MultiColumnRowView.kt
@@ -41,6 +41,8 @@ class MultiColumnRowView @JvmOverloads constructor(
     private val isMultiRow: Boolean
         get() = resources.configuration.fontScale > MAX_SINGLE_LINE_FONT_SCALE
 
+    var hasCustomWholeRowDescription: Boolean = false
+
     init {
         attrs?.let {
             val typedArray = context.theme.obtainStyledAttributes(it, R.styleable.MultiColumnRowView, 0, 0)
@@ -199,6 +201,12 @@ class MultiColumnRowView @JvmOverloads constructor(
             rowText2.isFocusable = focusable
             rowText3.isFocusable = focusable
         }
+    }
+
+    fun setWholeRowContentDescription(desc1: CharSequence?) {
+        hasCustomWholeRowDescription = true
+        setTextFocusable(false)
+        contentDescription = desc1
     }
 
     companion object {

--- a/components/src/main/java/uk/gov/hmrc/components/organism/summary/SummaryRowView.kt
+++ b/components/src/main/java/uk/gov/hmrc/components/organism/summary/SummaryRowView.kt
@@ -115,9 +115,10 @@ class SummaryRowView @JvmOverloads constructor(
             row.setTextStyle(rowStyle)
             row.setPadding(0, resources.getDimensionPixelOffset(R.dimen.hmrc_spacing_8), 0, 0)
 
-            when (readerTrait) {
-                READER_TRAIT_INFO -> row.setTextFocusable(true)
-                READER_TRAIT_SIMPLE -> row.setTextFocusable(false)
+            when {
+                row.hasCustomWholeRowDescription -> row.isFocusable = true
+                readerTrait == READER_TRAIT_INFO -> row.setTextFocusable(true)
+                readerTrait == READER_TRAIT_SIMPLE -> row.setTextFocusable(false)
             }
 
             binding.rowContainer.addView(row)

--- a/sample/src/main/java/uk/gov/hmrc/components/sample/molecules/MultiColumnRowFragment.kt
+++ b/sample/src/main/java/uk/gov/hmrc/components/sample/molecules/MultiColumnRowFragment.kt
@@ -46,5 +46,9 @@ class MultiColumnRowFragment : BaseComponentsFragment() {
                 Toast.makeText(context, "text 3 custom action invoked", LENGTH_LONG).show()
             }
         }
+
+        binding.multiColumnRowExample3.apply {
+            setWholeRowContentDescription(getString(R.string.multi_column_row_example_text_1_2_content_description))
+        }
     }
 }

--- a/sample/src/main/java/uk/gov/hmrc/components/sample/organisms/SummaryRowFragment.kt
+++ b/sample/src/main/java/uk/gov/hmrc/components/sample/organisms/SummaryRowFragment.kt
@@ -61,20 +61,26 @@ class SummaryRowFragment : BaseComponentsFragment() {
     @Suppress("LongMethod")
     private fun setupExampleRows() {
         val example1aRow1 = MultiColumnRowView(requireContext())
-        example1aRow1.setText(
-            getString(R.string.summary_row_example_1a_row1_text1),
-            getString(R.string.summary_row_example_1a_row1_text2)
-        )
+        example1aRow1.apply {
+            val text1 = getString(R.string.summary_row_example_1a_row1_text1)
+            val text2 = getString(R.string.summary_row_example_1a_row1_text2)
+            setText(text1, text2)
+            setWholeRowContentDescription("$text1: $text2")
+        }
         val example1aRow2 = MultiColumnRowView(requireContext())
-        example1aRow2.setText(
-            getString(R.string.summary_row_example_1a_row2_text1),
-            getString(R.string.summary_row_example_1a_row2_text2)
-        )
+        example1aRow2.apply {
+            val text1 = getString(R.string.summary_row_example_1a_row2_text1)
+            val text2 = getString(R.string.summary_row_example_1a_row2_text2)
+            setText(text1, text2)
+            setWholeRowContentDescription("$text1: $text2")
+        }
         val example1aRow3 = MultiColumnRowView(requireContext())
-        example1aRow3.setText(
-            getString(R.string.summary_row_example_1a_row3_text1),
-            getString(R.string.summary_row_example_1a_row3_text2)
-        )
+        example1aRow3.apply {
+            val text1 = getString(R.string.summary_row_example_1a_row3_text1)
+            val text2 = getString(R.string.summary_row_example_1a_row3_text2)
+            setText(text1, text2)
+            setWholeRowContentDescription("$text1: $text2")
+        }
         binding.summaryRowExample1a.apply {
             setRows(arrayListOf(example1aRow1, example1aRow2, example1aRow3))
             setOnClickListener { onCtaPressed() }

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -141,6 +141,7 @@
 
     <string name="multi_column_row_example_text_1">Estimated annual income</string>
     <string name="multi_column_row_example_text_2">£24,000</string>
+    <string name="multi_column_row_example_text_1_2_content_description">Estimated annual income is £24,000</string>
     <string name="multi_column_row_example_text_3">£31,865</string>
     <string name="multi_column_row_example_text_4">20%</string>
     <string name="multi_column_row_example_text_5">£6,373</string>


### PR DESCRIPTION
# 📝 Description

Allows screenreader focus on the whole MultiColumnRowView with a custom content description. This also applies per row, when used inside a SummaryRowView.
  
- [x] Updated CHANGELOG
- [ ] Updated README

# 🛠 Testing Notes

I have updated the sample app to demonstrate this:
- SummaryRowView: the first Sainsbury's PLC example (note: the eastwood charter school example below it still uses the previous implementation which remains as a valid usage of the component.)
- MultiColumnRowView: the third example ("Estimated annual income  £24,000") 

# 📸 Screenshots
