### PR TITLE
Prefix select row group errors with "Error:" announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Allowed headings:
 
 ## [Unreleased]
 
+### Changed
+
+* When an error is displayed on a `SelectRowGroup` component, then the error content description will have the prefix "Error:"
+
 ## [4.3.1] - 2022-12-28
 
 ### Additions

--- a/components/src/main/java/uk/gov/hmrc/components/molecule/selectrow/SelectRowGroup.kt
+++ b/components/src/main/java/uk/gov/hmrc/components/molecule/selectrow/SelectRowGroup.kt
@@ -90,9 +90,14 @@ class SelectRowGroup @JvmOverloads constructor(
     }
 
     fun setError(error: String) {
+        val errorContentDescription = if (error.isNotEmpty()) {
+            context.getString(R.string.accessibility_error_prefix, error)
+        } else error
+
         binding.selectRowError.apply {
             text = error
-            if (error.isNotEmpty()) announceForAccessibility(error)
+            contentDescription = errorContentDescription
+            if (error.isNotEmpty()) announceForAccessibility(errorContentDescription)
             visibility = if (error.isNotEmpty()) View.VISIBLE else View.GONE
         }
     }

--- a/components/src/main/java/uk/gov/hmrc/components/molecule/selectrow/SelectRowGroup.kt
+++ b/components/src/main/java/uk/gov/hmrc/components/molecule/selectrow/SelectRowGroup.kt
@@ -90,15 +90,17 @@ class SelectRowGroup @JvmOverloads constructor(
     }
 
     fun setError(error: String) {
-        val errorContentDescription = if (error.isNotEmpty()) {
-            context.getString(R.string.accessibility_error_prefix, error)
-        } else error
-
         binding.selectRowError.apply {
             text = error
-            contentDescription = errorContentDescription
-            if (error.isNotEmpty()) announceForAccessibility(errorContentDescription)
-            visibility = if (error.isNotEmpty()) View.VISIBLE else View.GONE
+            if (error.isNotEmpty()) {
+                val errorContentDescription = context.getString(R.string.accessibility_error_prefix, error)
+                contentDescription = errorContentDescription
+                announceForAccessibility(errorContentDescription)
+                visibility = View.VISIBLE
+            } else {
+                contentDescription = error
+                visibility = View.GONE
+            }
         }
     }
 


### PR DESCRIPTION
# 📝 Description

When an error is displayed on a SelectRowGroup component, then the error content description will have the prefix "Error:"
  
- [x] Updated CHANGELOG
- [ ] Updated README

# 🛠 Testing Notes

# 📸 Screenshots
