### PR TITLE
HMA-6086 make public edit mode getter on ELV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Allowed headings:
 
 ## [Unreleased]
 
+### Changed
+
+* `EditableListView` changed to have public `editMode` getter.
+
 ## [4.5.0] - 2023-02-17
 
 ### Changed

--- a/components/src/main/java/uk/gov/hmrc/components/organism/editable/EditableListView.kt
+++ b/components/src/main/java/uk/gov/hmrc/components/organism/editable/EditableListView.kt
@@ -42,7 +42,8 @@ open class EditableListView @JvmOverloads constructor(
     private var buttonIcon: Pair<Int, Int> = Pair(0, 0)
     private lateinit var editableListViewAdapter: EditableListViewAdapter
     private var editableItems = ArrayList<EditableListItemViewState>()
-    private var editMode = false
+    var editMode = false
+        private set
 
     init {
         attrs?.let {


### PR DESCRIPTION
# 📝 Description
EditableListView changed to have public editMode for use in HMA-6086
Github Issue
https://github.com/hmrc/android-components/issues/?
  
- [ ] Updated CHANGELOG
- [ ] Updated README

# 🛠 Testing Notes

# 📸 Screenshots
