### PR TITLE
SelectRowView alignment

### DIFF
--- a/components-compose/CHANGELOG.md
+++ b/components-compose/CHANGELOG.md
@@ -19,9 +19,6 @@ Allowed headings:
 ### Changed
 
 * `SelectRowView` aligned to top of radio button rather than centered
-
-### Changed
-
 * Dependency updates
 
 ## [0.1.1] - 2024-08-08Z

--- a/components-compose/CHANGELOG.md
+++ b/components-compose/CHANGELOG.md
@@ -18,6 +18,10 @@ Allowed headings:
 
 ### Changed
 
+* `SelectRowView` aligned to top of radio button rather than centered
+
+### Changed
+
 * Dependency updates
 
 ## [0.1.1] - 2024-08-08Z

--- a/components-compose/src/main/java/uk/gov/hmrc/components/compose/molecule/selectrow/SelectRowView.kt
+++ b/components-compose/src/main/java/uk/gov/hmrc/components/compose/molecule/selectrow/SelectRowView.kt
@@ -89,7 +89,7 @@ object SelectRowView {
                     } else 0.dp
                     selectRowViewItems.forEachIndexed { index, rowItem ->
                         Row(
-                            verticalAlignment = Alignment.CenterVertically,
+                            verticalAlignment = Alignment.Top,
                             modifier = modifier
                                 .selectable(
                                     selected = selectedRowItem == rowItem,


### PR DESCRIPTION
# 📝 Description

Github Issue
https://github.com/hmrc/android-components/issues/?
  
- [ x ] Updated CHANGELOG
- [ ] Updated README

# 🛠 Testing Notes
Check SelectRowView (and Bottom Sheets when using) have radio button aligned to top of text

# 📸 Screenshots
![SRV](https://github.com/user-attachments/assets/372a7b5d-b77a-46f0-89b6-577c9e51f34f)
