### PR TITLE
Update modifier usage for buttons

### DIFF
--- a/components-compose/CHANGELOG.md
+++ b/components-compose/CHANGELOG.md
@@ -16,6 +16,10 @@ Allowed headings:
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed Modifier usage on all `HmrcButton` types
+
 ## [0.1.3] - 2024-08-28Z
 
 ### Fixed

--- a/components-compose/src/main/java/uk/gov/hmrc/components/compose/atom/button/Button.kt
+++ b/components-compose/src/main/java/uk/gov/hmrc/components/compose/atom/button/Button.kt
@@ -72,7 +72,7 @@ fun HmrcButton(
             fontSize = 16.sp,
             fontWeight = FontWeight.Normal,
             textAlign = textAlign,
-            modifier = modifier.weight(1f)
+            modifier = Modifier.weight(1f)
         )
     }
 }
@@ -134,12 +134,12 @@ fun IconButton(
     textAlign: TextAlign = TextAlign.Start,
     onClick: () -> Unit,
 ) {
-    SecondaryButton(text = text, modifier = Modifier, textAlign = textAlign, onClick = onClick) {
+    SecondaryButton(text = text, modifier = modifier, textAlign = textAlign, onClick = onClick) {
         Icon(
             painter = painterResource(id = iconResId),
             contentDescription = null,
-            modifier = modifier.size(HmrcTheme.dimensions.hmrcIconSize24)
+            modifier = Modifier.size(HmrcTheme.dimensions.hmrcIconSize24)
         )
-        Spacer(modifier = modifier.width(HmrcTheme.dimensions.hmrcSpacing16))
+        Spacer(modifier = Modifier.width(HmrcTheme.dimensions.hmrcSpacing16))
     }
 }

--- a/sample-compose-fragments/src/main/java/uk/gov/hmrc/sample_compose_fragments/presentation/screens/atoms/ButtonScreen.kt
+++ b/sample-compose-fragments/src/main/java/uk/gov/hmrc/sample_compose_fragments/presentation/screens/atoms/ButtonScreen.kt
@@ -20,9 +20,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import uk.gov.hmrc.components.compose.atom.button.IconButton
 import uk.gov.hmrc.components.compose.atom.button.PrimaryButton
 import uk.gov.hmrc.components.compose.atom.button.SecondaryButton
+import uk.gov.hmrc.components.compose.ui.theme.HmrcTheme
 import uk.gov.hmrc.components.compose.ui.theme.HmrcTheme.dimensions
 import uk.gov.hmrc.sample_compose_components.R
 import uk.gov.hmrc.sample_compose_fragments.presentation.screens.sampletemplate.ScreenScrollViewColumn
@@ -41,5 +43,13 @@ fun ButtonScreen() {
             iconResId = R.drawable.ic_info,
             onClick = {}
         )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ButtonScreenPreview() {
+    HmrcTheme {
+        ButtonScreen()
     }
 }


### PR DESCRIPTION
# 📝 Description

The previous implementation meant that if, for example, a modifier with some padding was added to the implementation of a button, it would mess up the spacing within the button elements such as text or icons as they were using the same modifier. This has now been fixed.
  
- [x] Updated CHANGELOG
- [ ] Updated README

# 🛠 Testing Notes

# 📸 Screenshots
