### PR TITLE
HMA-9537-RubyInstaller 3.1.0-1 and later use the x64-mingw-ucrt platform for R…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,6 +207,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw-ucrt
 
 DEPENDENCIES
   fastlane


### PR DESCRIPTION
…uby and gems.

# 📝 Description

Github Issue
https://github.com/hmrc/android-components/issues/?

HMA-9537
  
- [ ] Updated CHANGELOG
- [ ] Updated README

# 🛠 Testing Notes

# 📸 Screenshots
