### PR TITLE
HMA-9567 - Navigation arrows for dark mode in compose

### DIFF
--- a/components-compose/CHANGELOG.md
+++ b/components-compose/CHANGELOG.md
@@ -20,6 +20,8 @@ Allowed headings:
 
 * Updated the component with dark mode navigation icon for `SummaryRowView`
 
+## [0.1.7] - 2025-01-10Z
+
 ### Changed
 
 * Updated the component with link text style for `SummaryRowView`
@@ -107,7 +109,7 @@ feature/HMA-5091-Android-Jetpack-Compose-Components-SummaryRowView
 ### Changed
 
 * Changed how SelectRowGroup works. It now takes a list of `SelectRowViewItem` to populate the rows, and requires a
-selected item rather than relying on position.
+  selected item rather than relying on position.
 
 ## [0.0.4] - 2024-04-12Z
 

--- a/components-compose/CHANGELOG.md
+++ b/components-compose/CHANGELOG.md
@@ -18,6 +18,10 @@ Allowed headings:
 
 ### Changed
 
+* Updated the component with dark mode navigation icon for `SummaryRowView`
+
+### Changed
+
 * Updated the component with link text style for `SummaryRowView`
 
 ## [0.1.6] - 2024-11-18Z

--- a/components-compose/src/main/java/uk/gov/hmrc/components/compose/organism/summaryrow/SummaryRowView.kt
+++ b/components-compose/src/main/java/uk/gov/hmrc/components/compose/organism/summaryrow/SummaryRowView.kt
@@ -17,6 +17,7 @@ package uk.gov.hmrc.components.compose.organism.summaryrow
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -31,6 +32,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
@@ -39,6 +41,8 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import uk.gov.hmrc.components.compose.R
+import uk.gov.hmrc.components.compose.ui.theme.HmrcBlack
+import uk.gov.hmrc.components.compose.ui.theme.HmrcBlackDark
 import uk.gov.hmrc.components.compose.ui.theme.HmrcRippleTheme
 import uk.gov.hmrc.components.compose.ui.theme.HmrcTheme.dimensions
 import uk.gov.hmrc.components.compose.ui.theme.HmrcTheme.typography
@@ -80,6 +84,13 @@ fun SummaryRowView(
                 Spacer(modifier = Modifier.width(dimensions.hmrcSpacing8))
                 Image(
                     painter = icon,
+                    colorFilter = ColorFilter.tint(
+                        if (isSystemInDarkTheme()){
+                            HmrcBlackDark
+                        }else{
+                            HmrcBlack
+                        }
+                    ),
                     modifier = Modifier
                         .semantics { role = Role.Button }
                         .clickable { onSummaryRowClicked() },

--- a/components-compose/src/main/java/uk/gov/hmrc/components/compose/organism/summaryrow/SummaryRowView.kt
+++ b/components-compose/src/main/java/uk/gov/hmrc/components/compose/organism/summaryrow/SummaryRowView.kt
@@ -85,9 +85,9 @@ fun SummaryRowView(
                 Image(
                     painter = icon,
                     colorFilter = ColorFilter.tint(
-                        if (isSystemInDarkTheme()){
+                        if (isSystemInDarkTheme()) {
                             HmrcBlackDark
-                        }else{
+                        } else {
                             HmrcBlack
                         }
                     ),


### PR DESCRIPTION
# 📝 Description

Github Issue
https://github.com/hmrc/android-components/issues/?

HMA-9567
  
- [ ] Updated CHANGELOG
- [ ] Updated README

# 🛠 Testing Notes

# 📸 Screenshots
